### PR TITLE
dont error on epipe

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -8,6 +8,16 @@ const versions = lines
   .map((l) => l.trim())
   .filter((l) => l);
 
-for (const { version } of semverSort(...versions)) {
-  console.log(version);
+try {
+  for (const { version } of semverSort(...versions)) {
+    console.log(version);
+  }
+} catch (err) {
+  const { code } = err
+  if (code === "EPIPE") {
+    // ignore, this can happen if stdout is closed by a piped process
+    // such as `semver-sort | head -n 1` which will close stdout after a single line.
+  } else {
+    throw err;
+  }
 }

--- a/main.ts
+++ b/main.ts
@@ -13,7 +13,7 @@ try {
     console.log(version);
   }
 } catch (err) {
-  const { code } = err
+  const { code } = err;
   if (code === "EPIPE") {
     // ignore, this can happen if stdout is closed by a piped process
     // such as `semver-sort | head -n 1` which will close stdout after a single line.


### PR DESCRIPTION
## Proposed changes

This change will handle the case where the stdout pipe is terminated unexpectedly. This can happen if the process is piped to another process which exits early, such as `semver-sort | head -n 1`. The `head` process will exit after the first line is produced and subsequent calls to `console.log` will fail with error code `EPIPE`.

In that case gracefully close the process with no errors.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist

- [x] I have read the
      [CONTRIBUTING](https://github.com/Optum/oss-template/blob/main/CONTRIBUTING.md)
      doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
