### PR TITLE
Support parsing python pre-release versions

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -8,6 +8,16 @@ const versions = lines
   .map((l) => l.trim())
   .filter((l) => l);
 
-for (const { version } of semverSort(...versions)) {
-  console.log(version);
+try {
+  for (const { version } of semverSort(...versions)) {
+    console.log(version);
+  }
+} catch (err) {
+  const { code } = err;
+  if (code === "EPIPE") {
+    // ignore, this can happen if stdout is closed by a piped process
+    // such as `semver-sort | head -n 1` which will close stdout after a single line.
+  } else {
+    throw err;
+  }
 }

--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -42,17 +42,22 @@ Deno.test({
     assertEquals(parse(v), v);
   },
 });
-Deno.test({
-  name: "PARSE06",
-  fn: () => {
-    const v = parse("0.13.1.dev0");
-    assertEquals(v.toString(), "0.13.1-dev.0");
-  },
-});
-Deno.test({
-  name: "PARSE07",
-  fn: () => {
-    const v = parse("12.0.0b4");
-    assertEquals(v.toString(), "12.0.0-b.4");
-  },
-});
+
+const pythonVersions = [
+  ["0.13.1a0", "0.13.1-a.0"],
+  ["0.13.1b0", "0.13.1-b.0"],
+  ["0.13.1rc0", "0.13.1-rc.0"],
+  ["0.13.1.dev0", "0.13.1-dev.0"],
+  ["0.13.1.post0", "0.13.1-post.0"],
+];
+
+for (let i = 0; i < pythonVersions.length; i++) {
+  const [input, expected] = pythonVersions[i];
+  Deno.test({
+    name: `PY${i.toString().padStart(2, "0")}`,
+    fn: () => {
+      const v = parse(input);
+      assertEquals(v.toString(), expected);
+    },
+  });
+}

--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -51,7 +51,6 @@ Deno.test({
 });
 Deno.test({
   name: "PARSE07",
-  only: true,
   fn: () => {
     const v = parse("12.0.0b4");
     assertEquals(v.toString(), "12.0.0-b.4");

--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -47,5 +47,12 @@ Deno.test({
   fn: () => {
     const v = parse("0.13.1.dev0");
     assertEquals(v.toString(), "0.13.1-dev.0");
-  }
-})
+  },
+});
+Deno.test({
+  name: "PARSE07",
+  fn: () => {
+    const v = parse("12.0.0b4");
+    assertEquals(v.toString(), "12.0.0-b.4");
+  },
+});

--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -42,3 +42,10 @@ Deno.test({
     assertEquals(parse(v), v);
   },
 });
+Deno.test({
+  name: "PARSE06",
+  fn: () => {
+    const v = parse("0.13.1.dev0");
+    assertEquals(v.toString(), "0.13.1-dev.0");
+  }
+})

--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -51,6 +51,7 @@ Deno.test({
 });
 Deno.test({
   name: "PARSE07",
+  only: true,
   fn: () => {
     const v = parse("12.0.0b4");
     assertEquals(v.toString(), "12.0.0-b.4");

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -13,10 +13,13 @@ export function parse(version: Version): SemVer {
   // supports converting _most_ python versions into common semver
   // [N!]N(.N)*[{a|b|rc}N][.postN][.devN]
   //
-  // | example     | result       |
-  // | ----------- | ------------ |
-  // | 0.13.1.dev0 | 0.13.1-dev.0 |
-  // | 0.13.1b0    | 0.13.1-b.0   |
+  // | example      | result        |
+  // | ------------ | ------------- |
+  // | 0.13.1a0     | 0.13.1-a.0    |
+  // | 0.13.1b0     | 0.13.1-b.0    |
+  // | 0.13.1rc0    | 0.13.1-rc.0   |
+  // | 0.13.1.dev0  | 0.13.1-dev.0  |
+  // | 0.13.1.post0 | 0.13.1-post.0 |
   //
   const py = versionString.match(
     /^(\d+)[.](\d+)[.](\d+)[.]?(a|b|rc|dev|post)(\d+)$/,

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -7,10 +7,9 @@ export function parse(version: Version): SemVer {
   }
   let versionString = version.toString().trim();
 
-
   // Python version documentation:
   // https://peps.python.org/pep-0440/#public-version-identifiers
-  // 
+  //
   // supports converting _most_ python versions into common semver
   // [N!]N(.N)*[{a|b|rc}N][.postN][.devN]
   //
@@ -18,8 +17,10 @@ export function parse(version: Version): SemVer {
   // | ----------- | ------------ |
   // | 0.13.1.dev0 | 0.13.1-dev.0 |
   // | 0.13.1d0    | 0.13.1-d.0   |
-  // 
-  const py = versionString.match(/^(\d+)[.](\d+)[.](\d+)[.]?(a|b|rc|dev|post)(\d+)$/);
+  //
+  const py = versionString.match(
+    /^(\d+)[.](\d+)[.](\d+)[.]?(a|b|rc|dev|post)(\d+)$/,
+  );
   if (py) {
     const [, major, minor, patch, pre, dev] = py;
     versionString = `${major}.${minor}.${patch}-${pre}.${dev}`;

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -5,19 +5,23 @@ export function parse(version: Version): SemVer {
   if (version instanceof semver.SemVer) {
     return version;
   }
-  let versionString = version.toString();
+  let versionString = version.toString().trim();
 
-  // supports converting python pre-release versions into common semver
-  // e.g. `0.13.1.dev0` -> `0.13.1-dev.0`
-  const py0 = versionString.match(/(\d+)[.](\d+)[.](\d+)[.](\w+)(\d+)/);
-  if (py0) {
-    const [, major, minor, patch, pre, dev] = py0;
-    versionString = `${major}.${minor}.${patch}-${pre}.${dev}`;
-  }
-  // e.g. `0.13.1d0` -> `0.13.1-d.0`
-  const py1 = versionString.match(/(\d+)[.](\d+)[.](\d+)(\w+)(\d+)/);
-  if (py1) {
-    const [, major, minor, patch, pre, dev] = py1;
+
+  // Python version documentation:
+  // https://peps.python.org/pep-0440/#public-version-identifiers
+  // 
+  // supports converting _most_ python versions into common semver
+  // [N!]N(.N)*[{a|b|rc}N][.postN][.devN]
+  //
+  // | example     | result       |
+  // | ----------- | ------------ |
+  // | 0.13.1.dev0 | 0.13.1-dev.0 |
+  // | 0.13.1d0    | 0.13.1-d.0   |
+  // 
+  const py = versionString.match(/^(\d+)[.](\d+)[.](\d+)[.]?(a|b|rc|dev|post)(\d+)$/);
+  if (py) {
+    const [, major, minor, patch, pre, dev] = py;
     versionString = `${major}.${minor}.${patch}-${pre}.${dev}`;
   }
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -16,7 +16,7 @@ export function parse(version: Version): SemVer {
   // | example     | result       |
   // | ----------- | ------------ |
   // | 0.13.1.dev0 | 0.13.1-dev.0 |
-  // | 0.13.1d0    | 0.13.1-d.0   |
+  // | 0.13.1b0    | 0.13.1-b.0   |
   //
   const py = versionString.match(
     /^(\d+)[.](\d+)[.](\d+)[.]?(a|b|rc|dev|post)(\d+)$/,

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -5,7 +5,15 @@ export function parse(version: Version): SemVer {
   if (version instanceof semver.SemVer) {
     return version;
   }
-  const versionString = version.toString();
+  let versionString = version.toString();
+
+  // supports converting python pre-release versions into common semver
+  // e.g. `0.13.1.dev0` -> `0.13.1-dev.0`
+  const m = versionString.match(/(\d+)[.](\d+)[.](\d+)[.](\w+)(\d+)/);
+  if (m) {
+    const [, major, minor, patch, pre, dev] = m;
+    versionString = `${major}.${minor}.${patch}-${pre}.${dev}`;
+  }
 
   // supports converting partial versions such as 1, 1.0 into valid semantic versions.
   const parsed = semver.parse(versionString) ??

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -9,9 +9,15 @@ export function parse(version: Version): SemVer {
 
   // supports converting python pre-release versions into common semver
   // e.g. `0.13.1.dev0` -> `0.13.1-dev.0`
-  const m = versionString.match(/(\d+)[.](\d+)[.](\d+)[.](\w+)(\d+)/);
-  if (m) {
-    const [, major, minor, patch, pre, dev] = m;
+  const py0 = versionString.match(/(\d+)[.](\d+)[.](\d+)[.](\w+)(\d+)/);
+  if (py0) {
+    const [, major, minor, patch, pre, dev] = py0;
+    versionString = `${major}.${minor}.${patch}-${pre}.${dev}`;
+  }
+  // e.g. `0.13.1d0` -> `0.13.1-d.0`
+  const py1 = versionString.match(/(\d+)[.](\d+)[.](\d+)(\w+)(\d+)/);
+  if (py1) {
+    const [, major, minor, patch, pre, dev] = py1;
     versionString = `${major}.${minor}.${patch}-${pre}.${dev}`;
   }
 


### PR DESCRIPTION
## Proposed changes

Python pre-release versions aren't quite the same as standard semver. This change parses that case and transforms them into standard semver.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist

- [x] I have read the
      [CONTRIBUTING](https://github.com/Optum/oss-template/blob/main/CONTRIBUTING.md)
      doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
